### PR TITLE
Only display script's basename in help messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ trh-k🐚 $ tuc --log-level=info -c config.json
 
   ```text
   Usage:
-    thistle-bin/keygen-gcp-k -c CONFIG_FILE
+    keygen-gcp-k -c CONFIG_FILE
       If GCP KMS resources in CONFIG_FILE are already provisioned, prints out public key string.
       Otherwise, generates a new key pair in GCP KMS as specified in CONFIG_FILE.
       User needs to login to appropriate GCP account and project before invoking command.
@@ -248,6 +248,6 @@ trh-k🐚 $ tuc --log-level=info -c config.json
 
   ```text
   Usage:
-    thistle-bin/sign-gcp-k -c CONFIG_FILE SIGNABLE_STRING
+    sign-gcp-k -c CONFIG_FILE SIGNABLE_STRING
       Signs SIGNABLE_STRING using GCP resources specified in CONFIG_FILE
   ```

--- a/thistle-bin/keygen-gcp-k
+++ b/thistle-bin/keygen-gcp-k
@@ -106,7 +106,7 @@ keygen() {
 
 usage() {
   echo "Usage:"
-  echo "  $0 -c CONFIG_FILE"
+  echo "  ${0##*/} -c CONFIG_FILE"
   echo "    If GCP KMS resources in CONFIG_FILE are already provisioned, prints out public key string."
   echo "    Otherwise, generates a new key pair in GCP KMS as specified in CONFIG_FILE."
   echo "    User needs to login to appropriate GCP account and project before invoking command."

--- a/thistle-bin/sign-gcp-k
+++ b/thistle-bin/sign-gcp-k
@@ -86,7 +86,7 @@ sign() {
 
 usage() {
   echo "Usage:"
-  echo "  $0 -c CONFIG_FILE SIGNABLE_STRING"
+  echo "  ${0##*/} -c CONFIG_FILE SIGNABLE_STRING"
   echo "    Signs SIGNABLE_STRING using GCP resources specified in CONFIG_FILE"
 }
 


### PR DESCRIPTION
We drop the path prefixes from `keygen-gcp-k` and `sign-gcp-k`'s usage messages, and only show basenames.