### PR TITLE
Clarification on operations security

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ $ git clone https://github.com/thistletech/trh-k.git
 # Activate Hermit, and run subsequent commands in Hermit environment
 $ . trh-k/bin/activate-hermit
 # Paste the "Access Token" of the project obtained from Thistle portal, and type
-# enter + ctrl-d
+# `Enter + Ctrl-d`. Use this command to prevent the sensitive $THISTLE_TOKEN
+# from being logged in shell history
 trh-k🐚 $ export THISTLE_TOKEN=$(cat)
 trh-k🐚 $ trh init --persist /path/to/device-persist-storage \
   --public-key <PUBLIC_KEY>


### PR DESCRIPTION
Add a clarification on operations security, regarding the command to prevent leaking access token in shell history.